### PR TITLE
Migration to Google Analytics 4 (GA4)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ copyright:
   name:             dandyrilla
 
 # Google-analytics
-google-analytics:
+google_analytics:
   id:               "UA-126097508-1"
 
 # Disqus

--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ copyright:
 
 # Google-analytics
 google_analytics:
-  id:               "UA-126097508-1"
+  id:               "G-5Y5TE2CC1J"
 
 # Disqus
 disqus:

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,5 +1,5 @@
 {% if site.google_analytics %}
-<!-- Google Analytics -->
+<!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics.id }}"></script>
 <script>
     window.dataLayer = window.dataLayer || [];

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,10 +1,10 @@
-{% if site.google-analytics %}
+{% if site.google_analytics %}
 <!-- Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google-analytics.id }}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics.id }}"></script>
 <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', '{{ site.google-analytics.id }}');
+    gtag('config', '{{ site.google_analytics.id }}');
 </script>
 {% endif %}


### PR DESCRIPTION
This PR replaces Universal Analytics (UA) with Google Analytics 4 (GA4).

- [x] Change Google Analytics ID
- [x] Update gtag script 